### PR TITLE
store logs under XDG cache directory (~/.cache/StartLive/logs)

### DIFF
--- a/models/log/__init__.py
+++ b/models/log/__init__.py
@@ -19,7 +19,8 @@ def get_log_path(*, is_makedir: bool = True) -> tuple[str, str]:
         base_dir = os.path.join(base_dir, "logs")
         log_path = os.path.join(base_dir, "StartLive.log")
     elif system() == "Linux":
-        base_dir = os.path.join("var", "log", "StartLive")
+        base_dir = os.path.join(os.path.expanduser("~/.cache"), "StartLive",
+                                "logs")
         log_path = os.path.join(base_dir, "StartLive.log")
     elif system() == "Darwin":
         base_dir = os.path.join(os.path.expanduser("~"), "Library", "Logs",


### PR DESCRIPTION
移动了 Linux 下日志文件的位置，更符合 Linux 桌面软件的惯例，为 Linux 打包做准备～